### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/zerocoolproject/9930dce1-8437-4eae-ae02-3fe6acba89cd/be45c45b-0ae6-4d47-b256-1b48d6a6b98a/_apis/work/boardbadge/baa5cdce-f95e-4f7d-888c-668691b6e56d)](https://dev.azure.com/zerocoolproject/9930dce1-8437-4eae-ae02-3fe6acba89cd/_boards/board/t/be45c45b-0ae6-4d47-b256-1b48d6a6b98a/Microsoft.RequirementCategory)
 # This project is retired, archived, and no longer supported. You are welcome to continue to use and fork the repository.
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/zerocoolproject/9930dce1-8437-4eae-ae02-3fe6acba89cd/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.